### PR TITLE
Bug Fix: Make number generator go from 0 to 36

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -497,7 +497,7 @@ function setBet(e, n, t, o){
 }
 
 function spin(){
-	var winningSpin = Math.floor(Math.random() * 36);
+	var winningSpin = Math.floor(Math.random() * 37);
 	spinWheel(winningSpin);
 	setTimeout(function(){
 		if(numbersBet.includes(winningSpin)){


### PR DESCRIPTION
Math.random() gives you a random decimal between 0 and 1, not including 1. Multiply it by 37 to expand the range: Now it's a decimal between 0 and 37, not including 37. Math.floor() rounds down to the nearest whole number, so you get a whole number between 0 and 36.